### PR TITLE
Fix: define event interceptor type

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ NHP provide util `defineEventInterceptor` for `onProxyReq` and `onProxyRes`, it 
 So, you can use all utilities from [H3][H3]
 
 ```ts
-import { getCookies, setHeader } from 'h3'
+import { getCookie, setHeader } from 'h3'
 import { defineServer, defineEventInterceptor } from '@privyid/nhp/core'
 
 export default defineServer([
@@ -65,7 +65,7 @@ export default defineServer([
       const token = getCookie(event, 'session/token')
 
       if (token)
-        setHeader(proxyEvent, 'Authentication', `Bearer ${token}`)
+        setHeader(proxyEvent, 'Authorization', `Bearer ${token}`)
     }),
   },
 ])

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -6,7 +6,7 @@ export default defineNuxtConfig({
   typescript: {
     tsConfig: {
       compilerOptions: {
-        strict          : false,
+        strict          : true,
         strictNullChecks: true,
       },
     },

--- a/playground/server.config.ts
+++ b/playground/server.config.ts
@@ -15,7 +15,7 @@ export default defineServer([
       const token = getCookie(event, 'session/token')
 
       if (token)
-        setHeader(proxyEvent, 'Authentication', `Bearer ${token}`)
+        setHeader(proxyEvent, 'Authorization', `Bearer ${token}`)
     }),
   },
   {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,6 +1,7 @@
 import type * as http from 'node:http'
 import { type H3Event, createEvent } from 'h3'
 import { type Options } from 'http-proxy-middleware'
+import type { Request, Response } from 'http-proxy-middleware/dist/types'
 
 export interface ApiServer extends Options {
   name: string,
@@ -35,11 +36,11 @@ export type EventInterceptor = (proxyEvent: H3Event, event: H3Event) => unknown 
  * @param handler H3-Compabilities event handler
  */
 export function defineEventInterceptor (handler: EventInterceptor) {
-  return (proxy: unknown, req: http.IncomingMessage, res: http.ServerResponse<http.IncomingMessage>) => {
-    const event      = createEvent(req, res)
+  return (proxy: http.ClientRequest | http.IncomingMessage, req: Request, res: Response) => {
+    const event      = createEvent(req as http.IncomingMessage, res as http.ServerResponse<http.IncomingMessage>)
     const proxyEvent = createEvent(
-      proxy as http.IncomingMessage,
-      proxy as http.ServerResponse<http.IncomingMessage>,
+      proxy as unknown as http.IncomingMessage,
+      proxy as unknown as http.ServerResponse<http.IncomingMessage>,
     )
 
     handler(proxyEvent, event)


### PR DESCRIPTION
## Description

This PR addresses the following issues:

1. Fixing type error in `defineEventInterceptor` function
2. Updating TypeScript rules in the playground to strict mode

### 1. Fixing type error in `defineEventInterceptor`

The `defineEventInterceptor` function was throwing type errors due to incorrect type annotations. This PR fixes the type errors by updating the type declarations, ensuring proper type checking and improving code robustness.

### 2. Updating TypeScript rules to strict mode in the playground

The TypeScript rules in the playground were not set to strict mode, which can lead to potential issues and less reliable code. This PR sets the TypeScript rules to strict mode, enabling stricter type checking and improved code quality in the playground.